### PR TITLE
fix: reindex Typesense after docs deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,5 +74,8 @@ jobs:
             # Restart docs container with new image
             docker compose up -d buggregator-docs
 
+            # Reindex documentation in Typesense
+            docker compose run --rm docs-indexer
+
             # Clean up old images
             docker image prune -f


### PR DESCRIPTION
## What
Add `docker compose run --rm docs-indexer` step after docs container restart in the deploy workflow.

## Why
After deploying new docs, the Typesense search index was stale — it only got updated when manually running the indexer. New or changed pages weren't searchable until manual intervention.

## Testing
- Trigger a deploy (manual or release) and verify the docs-indexer step runs successfully in the GitHub Actions log
- Search for content from a recently updated page to confirm the index is current